### PR TITLE
Fix Typescript interface and multi step recipes

### DIFF
--- a/src/__tests__/Recipe_EN.test.ts
+++ b/src/__tests__/Recipe_EN.test.ts
@@ -198,3 +198,24 @@ test("Get nutrients in recipe - simple string (NLP)", async () => {
     throw new Error("fail");
   }
 });
+
+
+test("Get nutrients in multi step recipe - simple string (NLP)", async () => {
+  const recipe: string[] = ["2 1/2 liter milk", "5 quarter of orange"];
+  const result: IRecipeResult[] = await lib.getIngredientsFromText(
+    recipe,
+    true
+  );
+  expect(result).not.toBeUndefined();
+
+  if (result[0] && result[0].result && result[1] && result[1].result) {
+    expect(result[0].result.ingredient).toEqual("milk");
+    expect(result[0].result.unit).toEqual("l");
+    expect(result[0].result.amount).toEqual(1);
+
+    expect(result[1].result.ingredient).toEqual("orange");
+    expect(result[1].result.amount).toEqual(1.25);
+  } else {
+    throw new Error("fail");
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@ import ConversionsUtils, { IUnits } from "./helpers/conversions";
 export interface IRecipeResult {
   result?: {
     instruction: string;
-    unit: number;
-    amount: string;
+    unit: string;
+    amount: number;
     ingredient: string;
   };
   unknown: {
@@ -51,12 +51,13 @@ export default class RecipesParser {
     recipeInstructions: string[],
     returnUnitKey?: boolean
   ): IRecipeResult[] {
-    const output: IRecipeResult = {
-      unknown: {},
-    };
-
     // Parse and normalize the ingredients
     return _.map(recipeInstructions, (instruction: string) => {
+
+      const output: IRecipeResult = {
+        unknown: {},
+      };
+
       const recipeStr = instruction
         .replace("½", "1/2")
         .replace("⅓", "1/3")


### PR DESCRIPTION
- Fix Typescript `IRecipeResult ` interface where `unit` should be a string and `amount ` a number not vice versa.
- Fix output defined out of map scope results in incorrect output for multiple step recipes. Also add a test to cover this case.